### PR TITLE
Feature/resolve overlaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package relies heavily on [`Geopandas`](https://geopandas.org/en/stable/) a
 
 `pip install polyclean`
 
-This should install the package and all necessary dependencies
+This should install the package and all necessary dependencies.
 
 ### Windows
 Make sure you have the following packages installed *first*:

--- a/polyclean/__init__.py
+++ b/polyclean/__init__.py
@@ -2,7 +2,8 @@ __version__ = '0.1.7'
 
 from .polyclean import (
     eliminate,
-    eliminate_overlaps,
     fill_gaps,
     fill_holes,
+    identify_overlaps,
+    update_layer
 )

--- a/polyclean/__init__.py
+++ b/polyclean/__init__.py
@@ -2,6 +2,7 @@ __version__ = '0.1.7'
 
 from .polyclean import (
     eliminate,
+    eliminate_overlaps,
     fill_gaps,
     fill_holes,
 )

--- a/polyclean/__init__.py
+++ b/polyclean/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 
 from .polyclean import (
     eliminate,

--- a/polyclean/polyclean.py
+++ b/polyclean/polyclean.py
@@ -41,7 +41,12 @@ def eliminate(data: gpd.GeoDataFrame, field: str):
         # longest border with.
         parent_polys = [x for x in data[data[field].isna()].geometry if feature.intersects(x)]
         edges = {feature.intersection(pp).length: pp for pp in parent_polys}
-        lse_poly = max(edges.items(), key=operator.itemgetter(0))[1]
+
+        try:
+            lse_poly = max(edges.items(), key=operator.itemgetter(0))[1]
+        except ValueError:
+            warn('No longest edge found for feature. Skipping...')
+            continue
 
         # Merge (eliminate) the feature with the feature it shares the
         # longest edge with.
@@ -53,40 +58,6 @@ def eliminate(data: gpd.GeoDataFrame, field: str):
     eliminated = data[data[field].isna()]
 
     return eliminated
-
-
-def identify_overlaps(data: gpd.GeoDataFrame, flatten=True) -> gpd.GeoDataFrame:
-    """Identify regions of overlap between polygons.
-    
-    Parameters
-    ----------
-    data : gpd.GeoDataFrame
-
-    flatten : bool
-        Whether or not to flatten the original layer. Regions of overlap
-        will be burned into the original geometries, which will be 
-        modified to remove any overlap.
-    
-    Returns
-    -------
-    gpd.GeoDataFrame
-    """
-    groups = (data
-        .overlay(data, how='intersection', keep_geom_type=True)
-        .explode(index_parts=True)
-    )
-
-    # Assume non-overlapping areas will not have the same area
-    groups['area'] = groups.area.round(4)
-
-    overlapping_regions = groups.groupby('area').filter(lambda x: len(x) > 1)
-    overlapping_regions['overlap'] = 1
-
-    if flatten:
-        ovlps = overlapping_regions.dissolve().explode(index_parts=False)  # Remove duplicate regions
-        return update_layer(data, ovlps)
-    else:
-        return overlapping_regions
 
 
 def fill_gaps(data, remove_gaps=True):
@@ -108,12 +79,15 @@ def fill_gaps(data, remove_gaps=True):
 
     # Set geometry precision to prevent rounding artifiacts.
     data = _round_geometries(data)
-    data_boundary = _fill_boundary(data)
+    data_boundary = _round_geometries(_fill_boundary(data))
     
     print('Identifying gaps...')
-    gaps = data_boundary.overlay(data, how='difference', keep_geom_type=True).explode(index_parts=False)
+    gaps = (data_boundary
+        .overlay(data, how='difference', keep_geom_type=True)
+        .explode(index_parts=False)
+    )
     gaps['gap'] = 1
-    gaps['gap_area'] = gaps.area
+    gaps['gap_area'] = round(gaps.area, 3)
 
     gaps_filled = data.append(gaps)
 
@@ -162,6 +136,47 @@ def fill_holes(data, threshold):
     return gpd.GeoDataFrame(data, geometry=polys_updated, crs=data.crs)
 
 
+def identify_overlaps(data: gpd.GeoDataFrame, flatten=True) -> gpd.GeoDataFrame:
+    """Identify regions of overlap between polygons.
+    
+    Parameters
+    ----------
+    data : gpd.GeoDataFrame
+
+    flatten : bool
+        Whether or not to flatten the original layer. Regions of overlap
+        will be burned into the original geometries, which will be 
+        modified to remove any overlap.
+    
+    Returns
+    -------
+    gpd.GeoDataFrame
+    """
+    data = _round_geometries(data)
+
+    groups = (data
+        .overlay(data, how='intersection', keep_geom_type=True)
+        .explode(index_parts=True)
+    )
+
+    # Assume non-overlapping areas will not have the same area
+    groups['area'] = groups.area.round(3)
+    overlapping_regions = groups.groupby('area').filter(lambda x: len(x) > 1)
+    overlapping_regions['overlap'] = 1
+
+    if flatten:
+        # Remove duplicate regions
+        ovlps = (overlapping_regions
+            .dissolve()
+            .explode(index_parts=False)
+         ) 
+        ovlps = _round_geometries(ovlps)
+
+        return update_layer(data, ovlps)
+    else:
+        return overlapping_regions
+
+
 def update_layer(original_polys: gpd.GeoDataFrame, 
                  update_polys: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """Update a data frame with polygons from another.
@@ -184,7 +199,7 @@ def update_layer(original_polys: gpd.GeoDataFrame,
     # new geometries
     erased = (original_polys
         .overlay(update_polys, how='difference', keep_geom_type=True)
-        .explode(index_parts=False)
+        .explode(index_parts=True)
     )
 
     # Update ("burn in") the new shapes to the original layer.
@@ -231,6 +246,6 @@ def _round_geometries(data_frame: gpd.GeoDataFrame):
 def _round_coordinates(polygon: Polygon):
     rounded_coords = []
     for pt in polygon.exterior.coords:
-        rounded_coords.append((round(pt[0], 4), round(pt[1], 4)))
+        rounded_coords.append((round(pt[0], 3), round(pt[1], 3)))
     
     return Polygon(rounded_coords)


### PR DESCRIPTION
<h3> Adds </h3>

Functionality to resolve overlaps between polygons. A function `identify_overlaps()` is added that identifies overlapping regions between polygons, and can return a flattened layer with the argument `flatten=True`. 

<h3> Extras </h3>
- Geometries are rounded to 3 decimal places to reduce the occurrence of floating point precision errors.
- Code is reorganized alphabetically

